### PR TITLE
feat: low-level support for v1 messaging

### DIFF
--- a/lib/src/content.dart
+++ b/lib/src/content.dart
@@ -1,0 +1,76 @@
+import 'package:fixnum/fixnum.dart';
+import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
+
+import './auth.dart';
+import './contact.dart';
+import './crypto.dart';
+
+/// This decrypts the `msg` using the `keys`.
+/// It derives the 3DH secret and uses that to decrypt the ciphertext.
+Future<xmtp.EncodedContent> decryptMessageV1(
+  xmtp.MessageV1 msg,
+  xmtp.PrivateKeyBundle keys,
+) async {
+  var header = xmtp.MessageHeaderV1.fromBuffer(msg.headerBytes);
+  var recipientAddress = header
+      .recipient.identityKey.secp256k1Uncompressed.bytes
+      .toEthereumAddress();
+  var isRecipientMe = recipientAddress == keys.identity.address;
+  var me = isRecipientMe ? header.recipient : header.sender;
+  var peer = !isRecipientMe ? header.recipient : header.sender;
+
+  var mePreAddress = me.preKey.secp256k1Uncompressed.bytes.toEthereumAddress();
+  var secret = compute3DHSecret(
+    createECPrivateKey(keys.identity.privateKey),
+    createECPrivateKey(keys.getPre(mePreAddress).privateKey),
+    createECPublicKey(peer.identityKey.secp256k1Uncompressed.bytes),
+    createECPublicKey(peer.preKey.secp256k1Uncompressed.bytes),
+    isRecipientMe,
+  );
+  var decrypted = await decrypt(
+    secret,
+    msg.ciphertext,
+    aad: msg.headerBytes,
+  );
+  return xmtp.EncodedContent.fromBuffer(decrypted);
+}
+
+/// This uses `keys` to encrypt the `content` as a [xmtp.MessageV1]
+/// to `recipient`.
+/// It derives the 3DH secret and uses that to encrypt the ciphertext.
+Future<xmtp.MessageV1> encryptMessageV1(
+  xmtp.PrivateKeyBundle keys,
+  xmtp.PublicKeyBundle recipient,
+  xmtp.EncodedContent content,
+) async {
+  var isRecipientMe = false;
+  var secret = compute3DHSecret(
+    createECPrivateKey(keys.identity.privateKey),
+    createECPrivateKey(keys.preKeys.first.privateKey),
+    createECPublicKey(recipient.identityKey.secp256k1Uncompressed.bytes),
+    createECPublicKey(recipient.preKey.secp256k1Uncompressed.bytes),
+    isRecipientMe,
+  );
+  var header = xmtp.MessageHeaderV1(
+    sender: xmtp.PublicKeyBundle(
+      identityKey: keys.toV1().identityKey.publicKey,
+      preKey: keys.toV1().preKeys.first.publicKey,
+    ),
+    recipient: recipient,
+    timestamp: Int64(DateTime.now().millisecondsSinceEpoch),
+  );
+  var headerBytes = header.writeToBuffer();
+  var ciphertext = await encrypt(secret, content.writeToBuffer(), aad: headerBytes);
+  return xmtp.MessageV1(
+    headerBytes: headerBytes,
+    ciphertext: ciphertext,
+  );
+}
+
+/// TODO: consider reorganizing when we introduce codecs
+final contentTypeText = xmtp.ContentTypeId(
+  authorityId: "xmtp.org",
+  typeId: "text",
+  versionMajor: 1,
+  versionMinor: 0,
+);

--- a/lib/src/topic.dart
+++ b/lib/src/topic.dart
@@ -11,16 +11,17 @@ class Topic {
 
   /// This represents direct message conversation between `sender` and `recipient`.
   /// NOTE: the addresses are normalized (EIP-55) and then sorted.
-  static String directMessage(String sender, String recipient) =>
-      _content('dm-${[
-        _normalize(sender),
-        _normalize(recipient),
-      ]
-        ..sort()
-        ..join('-')}');
+  static String directMessageV1(String senderAddress, String recipientAddress) {
+    var addresses = [
+      _normalize(senderAddress),
+      _normalize(recipientAddress),
+    ];
+    addresses.sort();
+    return _content('dm-${addresses.join('-')}');
+  }
 
-  /// This represents a direct message conversation.
-  static String directMessageV2(String randomString) =>
+  /// This represents a message conversation.
+  static String messageV2(String randomString) =>
       _content('m-$randomString');
 
   /// This represents a published contact for the user.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   fixnum: ^1.0.1
   flutter:
     sdk: flutter
+  pointycastle: ^3.6.0
   web3dart: ^2.4.1
   xmtp_proto: ^0.0.1-development
 

--- a/test/contact_test.dart
+++ b/test/contact_test.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:xmtp/src/signature.dart';
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 
 import 'package:xmtp/src/contact.dart';
@@ -43,19 +41,25 @@ void main() {
       178, 213, 204, 26, 75, 92, 233, 80, 192, 182, 201, 106,
       202, 182, 151, 44, 55, 16, 0,
     ]);
-    var contact = keyBundle.toContactBundle();
-    expect(
-      contact.wallet.hexEip55,
-      "0xb570d16466D9B35D1E96FA8bAdCe7C5c263C7c73",
-    );
-    expect(
-      contact.identity.hexEip55,
-      "0x5756f2Aa08d52111f2900c6C97b9611940620684",
-    );
-    expect(
-      contact.pre.hexEip55,
-      "0xBe658075774806ADf3E441870b1E6a4448682fec",
-    );
+    var contactV1 = createContactBundleV1(keyBundle);
+    var contactV2 = createContactBundleV2(keyBundle);
+    expect(contactV1.whichVersion(), xmtp.ContactBundle_Version.v1);
+    expect(contactV2.whichVersion(), xmtp.ContactBundle_Version.v2);
+
+    for (var contact in [contactV1, contactV2]) {
+      expect(
+        contact.wallet.hexEip55,
+        "0xb570d16466D9B35D1E96FA8bAdCe7C5c263C7c73",
+      );
+      expect(
+        contact.identity.hexEip55,
+        "0x5756f2Aa08d52111f2900c6C97b9611940620684",
+      );
+      expect(
+        contact.pre.hexEip55,
+        "0xBe658075774806ADf3E441870b1E6a4448682fec",
+      );
+    }
   });
 
   const serializedPublicKeyBundle = [


### PR DESCRIPTION
This includes the low-level bits required for V1 messaging.

It includes
- a refactor of how the auth uses private key bundles to more closely track the JS lib (i.e. storing/loading V1 bundles)
- adapters for converting between v1 `PublicKeys` and v2 `SignedPublicKeys`
- an implementation of our variation on X3DH for message encryption keys