### PR TITLE
build: add test network to CI and enable more tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,8 @@ jobs:
         with:
           flutter-version: '3.3.7'
           channel: 'stable'
+      - run: docker-compose -p xmtp -f "tool/local-node/docker-compose.yml" up -d
       - run: flutter pub get
-      - run: flutter test
+      - run: flutter test --dart-define=TEST_SERVER_ENABLED=true
+      - run: docker-compose -p xmtp -f "tool/local-node/docker-compose.yml" down
+        if: always()

--- a/test/auth_test.dart
+++ b/test/auth_test.dart
@@ -50,7 +50,7 @@ void main() {
   // It saves (encrypts) that key to the network storage
   // and then loads (decrypts) it back.
   test(
-    skip: !testServerEnabled,
+    skip: skipUnlessTestServerEnabled,
     "storing private keys",
     () async {
       var alice = EthPrivateKey.createRandom(Random.secure());

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -13,7 +13,7 @@ void main() {
   // This creates 2 new users with connected clients and
   // sends messages back and forth between them.
   test(
-    skip: !testServerEnabled,
+    skip: skipUnlessTestServerEnabled,
     "v1 messaging: intros, reading, writing, streaming",
     () async {
       var aliceWallet = EthPrivateKey.createRandom(Random.secure());

--- a/test/contact_test.dart
+++ b/test/contact_test.dart
@@ -141,7 +141,7 @@ void main() {
   );
 
   test(
-    skip: !testServerEnabled,
+    skip: skipUnlessTestServerEnabled,
     "contact creation / loading",
     () async {
       // Setup the API client.

--- a/test/conversation/conversation_v1_test.dart
+++ b/test/conversation/conversation_v1_test.dart
@@ -17,7 +17,7 @@ void main() {
   // This creates 2 users connected to the API and sends DMs
   // back and forth using message API V1.
   test(
-    skip: !testServerEnabled,
+    skip: skipUnlessTestServerEnabled,
     "v1 messaging: intros, reading, writing, streaming",
     () async {
       var aliceWallet = EthPrivateKey.createRandom(Random.secure());

--- a/test/conversation/conversation_v2_test.dart
+++ b/test/conversation/conversation_v2_test.dart
@@ -18,7 +18,7 @@ void main() {
   // This creates 2 users connected to the API and sends DMs
   // back and forth using message API V2.
   test(
-    skip: !testServerEnabled,
+    skip: skipUnlessTestServerEnabled,
     "v2 messaging: invites, reading, writing, streaming",
     () async {
       var aliceWallet = EthPrivateKey.createRandom(Random.secure());

--- a/test/test_server.dart
+++ b/test/test_server.dart
@@ -2,6 +2,7 @@ import 'package:xmtp/src/common/api.dart';
 
 /// This contains configuration for the test server.
 /// It pulls from the environment so we can configure it for CI.
+///  e.g. flutter test --dart-define=TEST_SERVER_ENABLED=true
 
 const testServerHost = String.fromEnvironment(
   "TEST_SERVER_HOST",
@@ -22,6 +23,13 @@ const testServerEnabled = bool.fromEnvironment(
   "TEST_SERVER_ENABLED",
   defaultValue: false,
 );
+
+/// Use this as the `skip: ` value on a test to skip the test
+/// when the test server is not enabled.
+/// Using this (instead of just `!testServerEnabled`) will print
+/// the note explaining why it was skipped.
+const skipUnlessTestServerEnabled =
+    !testServerEnabled ? "This test depends on the test server" : false;
 
 /// This creates an [Api] configured to talk to the test server.
 Api createTestServerApi() {


### PR DESCRIPTION
This spins up a local node during test runs and enables the tests that depend on it.