### PR TITLE
fix: use flutter command instead of dart for release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3
-      - run: dart pub get
-      - run: dart test
-      - run: dart pub publish --dry-run
+      - run: flutter pub get
+      - run: flutter test
+      - run: flutter pub publish --dry-run
       # TODO: drop "--dry-run" to auto-publish to pub.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.3
       - run: flutter pub get
-      - run: flutter test
+      - run: dart test
       - run: flutter pub publish --dry-run
       # TODO: drop "--dry-run" to auto-publish to pub.dev


### PR DESCRIPTION
This should resolve https://github.com/xmtp/xmtp-flutter/actions/runs/3735723057/jobs/6339281804 by replacing the `dart` command with the `flutter` command.