### PR TITLE
build: bump preview release version to development.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 0.0.1-development
+## 0.0.1-development.1
 
 - initial Developer Preview

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: xmtp
 description: XMTP client SDK for Flutter applications.
-version: 0.0.1-development
+version: 0.0.1-development.1
 repository: https://github.com/xmtp/xmtp-flutter
 
 environment:


### PR DESCRIPTION
This bumps the version so we can `dart pub publish` to pick up the latest docs.