### PR TITLE
feat: default to dev network instead of local

### DIFF
--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -15,9 +15,9 @@ class Api {
   Api._(this.client, this._metadata);
 
   factory Api.create({
-    String host = '127.0.0.1',
+    String host = 'dev.xmtp.network',
     int port = 5556,
-    bool isSecure = false,
+    bool isSecure = true,
     bool debugLogRequests = kDebugMode,
     String appVersion = "dev/0.0.0-development",
   }) {


### PR DESCRIPTION
Fixes https://github.com/xmtp/xmtp-flutter/issues/23
When trying to setup the example app locally. I ran into an issue with local versus dev. 
I think it will be easiest for others spinning up this environment to default to dev instead of local.