### PR TITLE
fix: sign v2 id key using .walletEcdsaCompact instead of .ecdsaCompact

### DIFF
--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -341,6 +341,15 @@ extension AuthPrivateKeyBundle on xmtp.PrivateKeyBundle {
   /// This is used for authentication with the API.
   ///  e.g. it is sent as the "authorization: Bearer $authToken".
   ///
+  /// Auth Token Signature Notes:
+  ///
+  /// The backend and xmtp-js disagree on how to sign an `.identityKey`:
+  ///  - the backend expects an `.ecdsaCompact` signature
+  ///  - the `xmtp-js` library expects a `.walletEcdsaCompact` signature
+  /// So we create this authToken (for the backend) signed `.ecdsaCompact`.
+  /// And we sign contact bundles (for xmtp-js etc) with `.walletEcdsaCompact`.
+  ///  See `createContactBundleV*()` in `contact.dart`.
+  ///
   /// NOTE: this can only be called on v1 bundles.
   /// TODO: consider supporting V2 key bundles
   Future<String> createAuthToken() async {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -235,7 +235,6 @@ void main() {
 
       var convo = await alice.newConversation(bob.address.hex);
 
-
       await alice.sendMessage(convo, "Here's a number:");
       await alice.sendMessage(convo, 12345, contentType: contentTypeInteger);
       await _delayToPropagate();

--- a/test/contact_test.dart
+++ b/test/contact_test.dart
@@ -169,8 +169,16 @@ void main() {
       var storedV2 = await contacts.getUserContactV2(alice.address.hexEip55);
       expect(storedV1.wallet, alice.address);
       expect(storedV1.whichVersion(), xmtp.ContactBundle_Version.v1);
+      expect(storedV1.v1.keyBundle.identityKey.signature.whichUnion(),
+          xmtp.Signature_Union.walletEcdsaCompact);
+      expect(storedV1.v1.keyBundle.preKey.signature.whichUnion(),
+          xmtp.Signature_Union.ecdsaCompact);
       expect(storedV2.wallet, alice.address);
       expect(storedV2.whichVersion(), xmtp.ContactBundle_Version.v2);
+      expect(storedV2.v2.keyBundle.identityKey.signature.whichUnion(),
+          xmtp.Signature_Union.walletEcdsaCompact);
+      expect(storedV2.v2.keyBundle.preKey.signature.whichUnion(),
+          xmtp.Signature_Union.ecdsaCompact);
       // Note: there's a difference here between the contact and auth token.
       //       The go backend expects auth tokens signed with `ecdsaCompact`.
       //       The js-lib expects contacts signed with `walletEcdsaCompact`.


### PR DESCRIPTION
We had reports of missing messages from `xmtp-flutter` apps in the example react app and other web clients that use `xmtp-js`. See #28. (See also https://github.com/xmtp/xmtp-ios/issues/28 which might be related)

This seems to fix that issue. The underlying cause was that the `xmtp-js` library only accepts `identityKey` signatures of type `.walletEcdsaCompact` but the `xmtp-flutter` library was signing the `identityKey` signature as type `.ecdasCompact`.

This PR converts the signature to the expected type when we assemble contact bundles.

Note: this PR doesn't change the `.identityKey` logic for creating auth tokens. This is because the backend has ([used to have](https://github.com/xmtp/xmtp-node-go/pull/193)) the opposite expectation for `.identityKey` signatures on auth tokens. Once that has rolled out, we can more consistently sign all `.identityKey` with signatures of type `.walletEcdsaCompact`.