### PR TITLE
fix: pin timestamp on invite to envelope, drop invalid

### DIFF
--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -27,7 +27,7 @@ void main() {
       var bobApi = createTestServerApi();
       var alice = await Client.createFromWallet(aliceApi, aliceWallet);
       var bob = await Client.createFromWallet(bobApi, bobWallet);
-      await _delayToPropagate();
+      await delayToPropagate();
       var aliceAddress = aliceWallet.address.hex;
       var bobAddress = bobWallet.address.hex;
 
@@ -53,7 +53,7 @@ void main() {
 
       // Alice sends the first message.
       await alice.sendMessage(aliceConvo, "hello Bob, it's me Alice!");
-      await _delayToPropagate();
+      await delayToPropagate();
 
       // It gets added to both of their conversation lists with that first msg.
       expect((await alice.listConversations()).length, 1);
@@ -67,7 +67,7 @@ void main() {
 
       // Bob replies
       await bob.sendMessage(bobConvo, "oh, hello Alice!");
-      await _delayToPropagate();
+      await delayToPropagate();
 
       aliceMessages = await alice.listMessages(aliceConvo);
       expect(aliceMessages.length, 2);
@@ -134,16 +134,16 @@ void main() {
       var bobApi = createTestServerApi();
       var alice = await Client.createFromWallet(aliceApi, aliceWallet);
       var bob = await Client.createFromWallet(bobApi, bobWallet);
-      await _delayToPropagate();
+      await delayToPropagate();
 
       var convo = await alice.newConversation(bob.address.hex,
           conversationId: "example.com");
       await alice.sendMessage(convo, "first message to convo");
-      await _delayToPropagate();
+      await delayToPropagate();
       await alice.sendMessage(convo, "second message to convo");
-      await _delayToPropagate();
+      await delayToPropagate();
       await alice.sendMessage(convo, "third message to convo");
-      await _delayToPropagate();
+      await delayToPropagate();
 
       var messages = await alice.listMessages(
         convo,
@@ -178,7 +178,7 @@ void main() {
       var bobApi = createTestServerApi();
       var alice = await Client.createFromWallet(aliceApi, aliceWallet);
       var bob = await Client.createFromWallet(bobApi, bobWallet);
-      await _delayToPropagate();
+      await delayToPropagate();
 
       var work = await alice.newConversation(
         bob.address.hex,
@@ -194,7 +194,7 @@ void main() {
       await alice.sendMessage(play, "Bob, let's chat here about play.");
       await alice.sendMessage(play, "I don't want to work.");
       await alice.sendMessage(play, "I just want to bang on my drum all day.");
-      await _delayToPropagate();
+      await delayToPropagate();
 
       var bobChats = await bob.listConversations();
       expect(bobChats.length, 2);
@@ -231,13 +231,13 @@ void main() {
         bobWallet,
         customCodecs: [IntegerCodec()],
       );
-      await _delayToPropagate();
+      await delayToPropagate();
 
       var convo = await alice.newConversation(bob.address.hex);
 
       await alice.sendMessage(convo, "Here's a number:");
       await alice.sendMessage(convo, 12345, contentType: contentTypeInteger);
-      await _delayToPropagate();
+      await delayToPropagate();
 
       expect((await bob.listMessages(convo)).map((m) => m.content).toList(), [
         12345,
@@ -246,7 +246,7 @@ void main() {
 
       await bob.sendMessage(convo, "Cool. Here's another:");
       await bob.sendMessage(convo, 67890, contentType: contentTypeInteger);
-      await _delayToPropagate();
+      await delayToPropagate();
 
       expect((await alice.listMessages(convo)).map((m) => m.content).toList(), [
         67890,
@@ -281,9 +281,6 @@ void main() {
     },
   );
 }
-
-/// A delay to allow messages to propagate before making assertions.
-_delayToPropagate() => Future.delayed(const Duration(milliseconds: 200));
 
 /// Simple [Codec] for sending [int] values around.
 ///

--- a/test/test_server.dart
+++ b/test/test_server.dart
@@ -42,3 +42,6 @@ Api createTestServerApi() {
     isSecure: testServerIsSecure,
   );
 }
+
+/// A delay to allow messages to propagate before making assertions.
+delayToPropagate() => Future.delayed(const Duration(milliseconds: 200));


### PR DESCRIPTION
This fixes #35 and unifies treatment for invalid envelopes with `xmtp-js`.

The envelope and the invite must have the same timestamp. 

Outgoing: Previously `xmtp-flutter` was constructing invites such that they could differ a bit (it was calling `nowNs()` twice). Now, with this PR, the timestamps are constructed to match.

Incoming: Previously `xmtp-flutter` didn't care if it received an invite with mismatching envelope/invite timestamps. This caused conversations to appear that were discarded by other clients. Now, with this PR, invites with mismatching timestamps are discarded (consistent with `xmtp-js`).