### PR TITLE
fix: fix the bad merge, trim spurious debug messages

### DIFF
--- a/lib/src/auth.dart
+++ b/lib/src/auth.dart
@@ -41,19 +41,15 @@ class AuthManager {
   Future<xmtp.PrivateKeyBundle> authenticateWithCredentials(
     Signer wallet,
   ) async {
-    debugPrint('AuthManager.authenticateWithCredentials()');
     xmtp.PrivateKeyBundle keys;
     var storedKeys = await _lookupPrivateKeys();
-    debugPrint('AuthManager storedKeys $storedKeys');
     if (storedKeys.isNotEmpty) {
-      debugPrint("prompting to enable existing identity");
       keys = await wallet.enableIdentityLoading(storedKeys.first);
       _checkKeys(keys);
       var authToken = await keys.createAuthToken();
       _api.setAuthToken(authToken);
       return this.keys = keys;
     } else {
-      debugPrint("prompting to create new identity");
       var identity = generateKeyPair();
       keys = await wallet.createIdentity(identity);
       _checkKeys(keys);
@@ -89,7 +85,6 @@ class AuthManager {
       contentTopics: [Topic.userPrivateStoreKeyBundle(_address.hex)],
       pagingInfo: xmtp.PagingInfo(limit: 10),
     ));
-    debugPrint("stored keys: ${stored.envelopes.length}");
     var result = <xmtp.EncryptedPrivateKeyBundle>[];
     for (var e in stored.envelopes) {
       try {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -178,7 +178,7 @@ void main() {
           await EthPrivateKey.createRandom(Random.secure()).asSigner();
       var aliceApi = createTestServerApi();
       var alice = await Client.createFromWallet(aliceApi, aliceWallet);
-      await _delayToPropagate();
+      await delayToPropagate();
 
       await expectLater(() async => alice.newConversation(alice.address.hex),
           throwsArgumentError);


### PR DESCRIPTION
The prior merge failed to sync the latest test helper name change. This fixes that and removes some log messages that made test runs harder to read.