### PR TITLE
Clarify that interoperable inbox is the default, add example app note

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ To learn more about XMTP and get answers to frequently asked questions, see [FAQ
 
 For a basic demonstration of the core concepts and capabilities of the `xmtp-flutter` client SDK, see the [Example app project](https://github.com/xmtp/xmtp-flutter/tree/main/example).
 
+> **Important**  
+> The example app includes a demonstration of how you might approach caching, or offline storage. Be aware that the example app naively performs a full refresh very frequently, **which causes slowdowns**. The underlying `xmtp-flutter` client SDK itself has no performance issues. If you want to provide offline storage in your app, be sure to design your refresh strategies with app performance in mind. Future versions of the example app aim to make this aspect easier to manage.
+
 ## Reference docs
 
 See the [xmtp library](https://pub.dev/documentation/xmtp/latest/xmtp/Client-class.html) for the Flutter client SDK reference documentation.
@@ -108,7 +111,7 @@ var listening = client.streamConversations().listen((convo) {
 await listening.cancel();
 ```
 
-These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of an interoperable inbox, which enables a user to access all of their conversations in any app built with XMTP.
+These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of a [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
 
 You might choose to provide an additional filtered view of conversations. To learn more, see [Handling multiple conversations with the same blockchain address](#handling-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ var listening = client.streamConversations().listen((convo) {
 await listening.cancel();
 ```
 
+These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of an interoperable inbox, which enables a user to access all of their conversations in any app built with XMTP.
+
+You might choose to provide an additional filtered view of conversations. To learn more, see [Handling multiple conversations with the same blockchain address](#handling-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+
 ### Start a new conversation
 
 You can create a new conversation with any Ethereum address on the XMTP network.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ for (var convo in conversations) {
 }
 ```
 
+These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of a [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
+
+You might choose to provide an additional filtered view of conversations. To learn more, see [Handling multiple conversations with the same blockchain address](#handling-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
+
 ### Listen for new conversations
 
 You can also listen for new conversations being started in real-time.
@@ -110,10 +114,6 @@ var listening = client.streamConversations().listen((convo) {
 // When you want to stop listening:
 await listening.cancel();
 ```
-
-These conversations include all conversations for a user **regardless of which app created the conversation.** This functionality provides the concept of a [interoperable inbox](https://xmtp.org/docs/dev-concepts/interoperable-inbox), which enables a user to access all of their conversations in any app built with XMTP.
-
-You might choose to provide an additional filtered view of conversations. To learn more, see [Handling multiple conversations with the same blockchain address](#handling-multiple-conversations-with-the-same-blockchain-address) and [Filter conversations using conversation IDs and metadata](https://xmtp.org/docs/client-sdk/javascript/tutorials/filter-conversations).
 
 ### Start a new conversation
 

--- a/example/README.md
+++ b/example/README.md
@@ -2,6 +2,9 @@
 
 An XMTP example app.
 
+> **Important**  
+> The example app includes a demonstration of how you might approach caching, or offline storage. Be aware that the example app naively performs a full refresh very frequently, **which causes slowdowns**. The underlying `xmtp-flutter` client SDK itself has no performance issues. If you want to provide offline storage in your app, be sure to design your refresh strategies with app performance in mind. Future versions of the example app aim to make this aspect easier to manage.
+
 ## Getting Started
 
 This project is a starting point for a Flutter application.


### PR DESCRIPTION
- Based on dev feedback, added a clarification that interoperable inboxes are the default state
- Also pulled the example app note into this PR. Thought it would be helpful to provide the note now. Don't need to wait for GA. =)