### PR TITLE
Bump version

### DIFF
--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:grpc/grpc.dart' as grpc;
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 
-const sdkVersion = '0.0.1';
+const sdkVersion = '0.0.2';
 const clientVersion = "xmtp-flutter/$sdkVersion";
 // TODO: consider generating these ^ during build.
 


### PR DESCRIPTION
Be nice to bump the version for the security release.

Wondering if we can automate this like we do on android: https://github.com/xmtp/xmtp-android/blob/main/.github/workflows/release.yml#L22-L33

But at the very least we can bump this to `0.0.2-development.1`