### PR TITLE
feat: add batch editions of list/stream messages and send encoded

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -198,6 +198,8 @@ class Client implements Codec<DecodedContent> {
 
   /// This lists messages sent to the [conversation].
   ///
+  /// For listing multiple conversations, see [listBatchMessages].
+  ///
   /// If [start] or [end] are specified then this will only list messages
   /// sent at or after [start] and at or before [end].
   ///
@@ -211,11 +213,29 @@ class Client implements Codec<DecodedContent> {
     int? limit,
     xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
   }) =>
-      _conversations.listMessages(conversation, start, end, limit, sort);
+      _conversations.listMessages([conversation], start, end, limit, sort);
+
+  /// This lists messages sent to the [conversations].
+  /// This is identical to [listMessages] except it pulls messages from
+  /// multiple conversations in a single call.
+  Future<List<DecodedMessage>> listBatchMessages(
+    Iterable<Conversation> conversations, {
+    DateTime? start,
+    DateTime? end,
+    int? limit,
+    xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
+  }) =>
+      _conversations.listMessages(conversations, start, end, limit, sort);
 
   /// This exposes a stream of new messages sent to the [conversation].
+  /// For streaming multiple conversations, see [streamBatchMessages].
   Stream<DecodedMessage> streamMessages(Conversation conversation) =>
-      _conversations.streamMessages(conversation);
+      _conversations.streamMessages([conversation]);
+
+  /// This exposes a stream of new messages sent to any of the [conversations].
+  Stream<DecodedMessage> streamBatchMessages(
+          Iterable<Conversation> conversations) =>
+      _conversations.streamMessages(conversations);
 
   /// This sends a new message to the [conversation].
   /// It returns the [DecodedMessage] to simplify optimistic local updates.
@@ -232,6 +252,15 @@ class Client implements Codec<DecodedContent> {
         content,
         contentType: contentType,
       );
+
+  /// This sends the already [encoded] message to the [conversation].
+  /// This is identical to [sendMessage] but can be helpful when you
+  /// have already encoded the message to send.
+  Future<DecodedMessage> sendMessageEncoded(
+    Conversation conversation,
+    xmtp.EncodedContent encoded,
+  ) =>
+      _conversations.sendMessageEncoded(conversation, encoded);
 
   /// These use all registered codecs to decode and encode content.
   ///

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -94,11 +94,8 @@ class ConversationManagerV1 {
   Future<Conversation> _conversationFromIntro(xmtp.Message msg) async {
     var header = xmtp.MessageHeaderV1.fromBuffer(msg.v1.headerBytes);
     var encoded = await decryptMessageV1(msg.v1, _auth.keys);
-    var decoded = await _codecs.decode(encoded);
-    var intro = _createDecodedMessage(
+    var intro = await _createDecodedMessage(
       msg,
-      decoded.contentType,
-      decoded.content,
       encoded,
     );
     var createdAt = intro.sentAt;
@@ -116,14 +113,17 @@ class ConversationManagerV1 {
   }
 
   Future<List<DecodedMessage>> listMessages(
-    Conversation conversation, [
+    Iterable<Conversation> conversations, [
     DateTime? start,
     DateTime? end,
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
+    if (conversations.isEmpty) {
+      return [];
+    }
     var listing = await _api.client.query(xmtp.QueryRequest(
-      contentTopics: [conversation.topic],
+      contentTopics: conversations.map((c) => c.topic),
       startTimeNs: start?.toNs64(),
       endTimeNs: end?.toNs64(),
       pagingInfo: xmtp.PagingInfo(
@@ -136,20 +136,22 @@ class ConversationManagerV1 {
         .map((msg) => _decodedFromMessage(msg)));
   }
 
-  Stream<DecodedMessage> streamMessages(Conversation conversation) =>
-      _api.client
-          .subscribe(xmtp.SubscribeRequest(contentTopics: [conversation.topic]))
-          .map((e) => xmtp.Message.fromBuffer(e.message))
-          .asyncMap((msg) => _decodedFromMessage(msg));
+  Stream<DecodedMessage> streamMessages(Iterable<Conversation> conversations) {
+    if (conversations.isEmpty) {
+      return const Stream.empty();
+    }
+    return _api.client
+        .subscribe(xmtp.SubscribeRequest(
+            contentTopics: conversations.map((c) => c.topic)))
+        .map((e) => xmtp.Message.fromBuffer(e.message))
+        .asyncMap((msg) => _decodedFromMessage(msg));
+  }
 
   /// This decrypts and decodes the [xmtp.Message].
   Future<DecodedMessage> _decodedFromMessage(xmtp.Message msg) async {
     var encoded = await decryptMessageV1(msg.v1, _auth.keys);
-    var decoded = await _codecs.decode(encoded);
     return _createDecodedMessage(
       msg,
-      decoded.contentType,
-      decoded.content,
       encoded,
     );
   }
@@ -161,6 +163,13 @@ class ConversationManagerV1 {
   }) async {
     contentType ??= contentTypeText;
     var encoded = await _codecs.encode(DecodedContent(contentType, content));
+    return sendMessageEncoded(conversation, encoded);
+  }
+
+  Future<DecodedMessage> sendMessageEncoded(
+    Conversation conversation,
+    xmtp.EncodedContent encoded,
+  ) async {
     var peerContact = await _contacts.getUserContactV1(conversation.peer.hex);
     var encrypted = await encryptMessageV1(
       _auth.keys,
@@ -181,7 +190,7 @@ class ConversationManagerV1 {
     ]));
 
     // This returns a decoded edition for optimistic local updates.
-    return _createDecodedMessage(msg, contentType, content, encoded);
+    return _createDecodedMessage(msg, encoded);
   }
 
   Future<xmtp.PublishResponse> _sendIntros(
@@ -203,6 +212,29 @@ class ConversationManagerV1 {
         ),
       ),
     ));
+  }
+
+  /// This creates the [DecodedMessage] from the various parts.
+  Future<DecodedMessage> _createDecodedMessage(
+    xmtp.Message dm,
+    xmtp.EncodedContent encoded,
+  ) async {
+    var decoded = await _codecs.decode(encoded);
+    var id = bytesToHex(sha256(dm.writeToBuffer()));
+    var header = xmtp.MessageHeaderV1.fromBuffer(dm.v1.headerBytes);
+    var sender = header.sender.wallet;
+    var sentAt = header.timestamp.toDateTime();
+    var topic = Topic.directMessageV1(sender.hex, header.recipient.wallet.hex);
+    return DecodedMessage(
+      xmtp.Message_Version.v1,
+      sentAt,
+      sender,
+      encoded,
+      decoded.contentType,
+      decoded.content,
+      id: id,
+      topic: topic,
+    );
   }
 }
 
@@ -266,29 +298,5 @@ Future<xmtp.MessageV1> encryptMessageV1(
   return xmtp.MessageV1(
     headerBytes: headerBytes,
     ciphertext: ciphertext,
-  );
-}
-
-/// This creates the [DecodedMessage] from the various parts.
-DecodedMessage _createDecodedMessage(
-  xmtp.Message dm,
-  xmtp.ContentTypeId contentType,
-  Object content,
-  xmtp.EncodedContent encoded,
-) {
-  var id = bytesToHex(sha256(dm.writeToBuffer()));
-  var header = xmtp.MessageHeaderV1.fromBuffer(dm.v1.headerBytes);
-  var sender = header.sender.wallet;
-  var sentAt = header.timestamp.toDateTime();
-  var topic = Topic.directMessageV1(sender.hex, header.recipient.wallet.hex);
-  return DecodedMessage(
-    xmtp.Message_Version.v1,
-    sentAt,
-    sender,
-    encoded,
-    contentType,
-    content,
-    id: id,
-    topic: topic,
   );
 }

--- a/lib/xmtp.dart
+++ b/lib/xmtp.dart
@@ -2,6 +2,7 @@
 /// for Flutter applications written in dart.
 library xmtp;
 
+export 'src/auth.dart' show CompatPrivateKeyBundle;
 export 'src/common/api.dart' show Api;
 export 'src/common/signature.dart' show Signer, CredentialsToSigner;
 export 'src/client.dart' show Client;

--- a/test/conversation/conversation_v1_test.dart
+++ b/test/conversation/conversation_v1_test.dart
@@ -38,17 +38,16 @@ void main() {
       var aliceConvo = await alice.newConversation(bobAddress);
       var bobConvo = await bob.newConversation(aliceAddress);
 
-      var aliceMessages = await alice.listMessages(aliceConvo);
-      var bobMessages = await bob.listMessages(bobConvo);
+      var aliceMessages = await alice.listMessages([aliceConvo]);
+      var bobMessages = await bob.listMessages([bobConvo]);
 
       expect(aliceMessages.length, 0);
       expect(bobMessages.length, 0);
 
       // Bob starts listening to the stream and recording the transcript.
       var transcript = [];
-      var bobListening = bob
-          .streamMessages(bobConvo)
-          .listen((msg) => transcript.add('${msg.sender.hex}> ${msg.content}'));
+      var bobListening = bob.streamMessages([bobConvo]).listen(
+          (msg) => transcript.add('${msg.sender.hex}> ${msg.content}'));
 
       // Wait a second to allow contacts to propagate.
       await Future.delayed(const Duration(seconds: 1));
@@ -61,7 +60,7 @@ void main() {
       expect((await bob.listConversations()).length, 1);
 
       // And Bob see the message in the conversation.
-      bobMessages = await bob.listMessages(bobConvo);
+      bobMessages = await bob.listMessages([bobConvo]);
       expect(bobMessages.length, 1);
       expect(bobMessages[0].sender, aliceWallet.address);
       expect(bobMessages[0].content, "hello Bob, it's me Alice!");
@@ -69,7 +68,7 @@ void main() {
       // Bob replies
       await bob.sendMessage(bobConvo, "oh, hello Alice!");
 
-      aliceMessages = await alice.listMessages(aliceConvo);
+      aliceMessages = await alice.listMessages([aliceConvo]);
       expect(aliceMessages.length, 2);
       expect(aliceMessages[0].sender, bobWallet.address);
       expect(aliceMessages[0].content, "oh, hello Alice!");
@@ -112,7 +111,7 @@ void main() {
       var conversations = await v1.listConversations();
       for (var convo in conversations) {
         debugPrint("dm w/ ${convo.peer}");
-        var dms = await v1.listMessages(convo);
+        var dms = await v1.listMessages([convo]);
         for (var j = 0; j < dms.length; ++j) {
           var dm = dms[j];
           debugPrint("${dm.sentAt} ${dm.sender.hexEip55}> ${dm.content}");

--- a/test/conversation/conversation_v2_test.dart
+++ b/test/conversation/conversation_v2_test.dart
@@ -59,16 +59,15 @@ void main() {
 
       // Bob starts listening to the stream and recording the transcript.
       var transcript = [];
-      var bobListening = bob
-          .streamMessages(bobConvo)
-          .listen((msg) => transcript.add('${msg.sender.hex}> ${msg.content}'));
+      var bobListening = bob.streamMessages([bobConvo]).listen(
+          (msg) => transcript.add('${msg.sender.hex}> ${msg.content}'));
 
       // Alice sends the first message.
       await alice.sendMessage(aliceConvo, "hello Bob, it's me Alice!");
       await delayToPropagate();
 
       // And Bob see the message in the conversation.
-      var bobMessages = await bob.listMessages(bobConvo);
+      var bobMessages = await bob.listMessages([bobConvo]);
       expect(bobMessages.length, 1);
       expect(bobMessages[0].sender, aliceWallet.address);
       expect(bobMessages[0].content, "hello Bob, it's me Alice!");
@@ -77,7 +76,7 @@ void main() {
       await bob.sendMessage(bobConvo, "oh, hello Alice!");
       await delayToPropagate();
 
-      var aliceMessages = await alice.listMessages(aliceConvo);
+      var aliceMessages = await alice.listMessages([aliceConvo]);
       expect(aliceMessages.length, 2);
       expect(aliceMessages[0].sender, bobWallet.address);
       expect(aliceMessages[0].content, "oh, hello Alice!");
@@ -118,14 +117,16 @@ void main() {
       var carlContact = createContactBundleV2(carlKeys);
 
       // Alice initiates the conversation (sending off the invites)
-      var aliceConvo = await alice.newConversation(bobAddress, xmtp.InvitationV1_Context(
-        conversationId: "example.com/sneaky-fake-sender-key-bundle",
-      ));
+      var aliceConvo = await alice.newConversation(
+          bobAddress,
+          xmtp.InvitationV1_Context(
+            conversationId: "example.com/sneaky-fake-sender-key-bundle",
+          ));
       await delayToPropagate();
       var bobConvo = (await bob.listConversations())[0];
 
       // Helper to inspect transcript (from Alice's perspective).
-      getTranscript() async => (await alice.listMessages(aliceConvo))
+      getTranscript() async => (await alice.listMessages([aliceConvo]))
           .reversed
           .map((msg) => '${msg.sender.hexEip55}> ${msg.content}');
 
@@ -286,7 +287,7 @@ void main() {
       expect(bobConvo.conversationId, "example.com/valid");
 
       // Helper to inspect transcript (from Alice's perspective).
-      getTranscript() async => (await alice.listMessages(aliceConvo))
+      getTranscript() async => (await alice.listMessages([aliceConvo]))
           .reversed
           .map((msg) => '${msg.sender.hex}> ${msg.content}');
 
@@ -374,7 +375,7 @@ void main() {
       var conversations = await v2.listConversations();
       for (var convo in conversations) {
         debugPrint("dm w/ ${convo.peer}");
-        var dms = await v2.listMessages(convo);
+        var dms = await v2.listMessages([convo]);
         for (var j = 0; j < dms.length; ++j) {
           var dm = dms[j];
           debugPrint("${dm.sentAt} ${dm.sender.hexEip55}> ${dm.content}");

--- a/tool/local-node/docker-compose.yml
+++ b/tool/local-node/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - --message-db-reader-connection-string=postgres://postgres:xmtp@db:5432/postgres?sslmode=disable
       - --lightpush
       - --filter
+      - --log-level=DEBUG
       - --ws-port=9001
       - --wait-for-db=30s
       - --api.authn.enable


### PR DESCRIPTION
This adds 3 new methods to the SDK for help with performance tuning:
- `listBatchMessages` -- lists messages from multiple conversations in a single call
- `streamBatchMessages` -- streams new messages from multiple conversations in a single call
- `sendMessageEncoded` -- sends a message that was already previously encoded