### PR TITLE
breaking: only allow a single query content topic

### DIFF
--- a/example/lib/session/background_manager.dart
+++ b/example/lib/session/background_manager.dart
@@ -114,8 +114,8 @@ class BackgroundManager {
         // TODO: do this in the query ^
         .where((c) => topicSet.contains(c.topic));
     return _refreshMessages(
-      conversations,
-      since: since,
+        conversations,
+        since: since,
     );
   }
 
@@ -123,12 +123,16 @@ class BackgroundManager {
     Iterable<xmtp.Conversation> conversations, {
     DateTime? since,
   }) async {
-    var messages = await _client.listBatchMessages(
-      conversations,
-      start: since,
-    );
-    await _db.saveMessages(messages);
-    return messages.length;
+    var messagesLength = 0;
+    for (var conversation in conversations) {
+      var messages = await _client.listMessages(
+        conversation,
+        start: since,
+      );
+      await _db.saveMessages(messages);
+      messagesLength += messages.length;
+    }
+    return messagesLength;
   }
 
   /// Refreshes the list of all conversations from the remote API.

--- a/example/lib/session/background_manager.dart
+++ b/example/lib/session/background_manager.dart
@@ -114,8 +114,8 @@ class BackgroundManager {
         // TODO: do this in the query ^
         .where((c) => topicSet.contains(c.topic));
     return _refreshMessages(
-        conversations,
-        since: since,
+      conversations,
+      since: since,
     );
   }
 

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -198,8 +198,6 @@ class Client implements Codec<DecodedContent> {
 
   /// This lists messages sent to the [conversation].
   ///
-  /// For listing multiple conversations, see [listBatchMessages].
-  ///
   /// If [start] or [end] are specified then this will only list messages
   /// sent at or after [start] and at or before [end].
   ///
@@ -213,19 +211,7 @@ class Client implements Codec<DecodedContent> {
     int? limit,
     xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
   }) =>
-      _conversations.listMessages([conversation], start, end, limit, sort);
-
-  /// This lists messages sent to the [conversations].
-  /// This is identical to [listMessages] except it pulls messages from
-  /// multiple conversations in a single call.
-  Future<List<DecodedMessage>> listBatchMessages(
-    Iterable<Conversation> conversations, {
-    DateTime? start,
-    DateTime? end,
-    int? limit,
-    xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
-  }) =>
-      _conversations.listMessages(conversations, start, end, limit, sort);
+      _conversations.listMessages(conversation, start, end, limit, sort);
 
   /// This exposes a stream of new messages sent to the [conversation].
   /// For streaming multiple conversations, see [streamBatchMessages].

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -113,17 +113,14 @@ class ConversationManagerV1 {
   }
 
   Future<List<DecodedMessage>> listMessages(
-    Iterable<Conversation> conversations, [
+    Conversation conversation, [
     DateTime? start,
     DateTime? end,
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
-    if (conversations.isEmpty) {
-      return [];
-    }
     var listing = await _api.client.query(xmtp.QueryRequest(
-      contentTopics: conversations.map((c) => c.topic),
+      contentTopics: [conversation.topic],
       startTimeNs: start?.toNs64(),
       endTimeNs: end?.toNs64(),
       pagingInfo: xmtp.PagingInfo(

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -197,18 +197,14 @@ class ConversationManagerV2 {
 
   /// This lists the current messages in the [conversations]
   Future<List<DecodedMessage>> listMessages(
-    Iterable<Conversation> conversations, [
+    Conversation conversation, [
     DateTime? start,
     DateTime? end,
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
-    if (conversations.isEmpty) {
-      return [];
-    }
-    var convoByTopic = {for (var c in conversations) c.topic: c};
     var listing = await api.client.query(xmtp.QueryRequest(
-      contentTopics: conversations.map((c) => c.topic),
+      contentTopics: [conversation.topic],
       startTimeNs: start?.toNs64(),
       endTimeNs: end?.toNs64(),
       pagingInfo: xmtp.PagingInfo(
@@ -217,9 +213,8 @@ class ConversationManagerV2 {
       ),
     ));
     var messages = await Future.wait(listing.envelopes
-        .where((e) => convoByTopic.containsKey(e.contentTopic))
         .map((e) => _decodedFromMessage(
-              convoByTopic[e.contentTopic]!,
+              conversation,
               xmtp.Message.fromBuffer(e.message),
             )));
     // Remove nulls (which are discarded bad envelopes).

--- a/lib/src/conversation/manager.dart
+++ b/lib/src/conversation/manager.dart
@@ -81,19 +81,19 @@ class ConversationManager {
 
   /// This lists the messages in [conversations].
   Future<List<DecodedMessage>> listMessages(
-    Iterable<Conversation> conversations, [
+    Conversation conversation, [
     DateTime? start,
     DateTime? end,
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
-    var cv1 = conversations.where((c) => c.version == xmtp.Message_Version.v1);
-    var cv2 = conversations.where((c) => c.version == xmtp.Message_Version.v2);
-    var messages = await Future.wait([
-      _v1.listMessages(cv1, start, end, limit, sort),
-      _v2.listMessages(cv2, start, end, limit, sort),
-    ]);
-    return messages.expand((m) => m).toList();
+    if (conversation.version == xmtp.Message_Version.v1) {
+      return await _v1.listMessages(conversation, start, end, limit, sort);
+    }
+    if (conversation.version == xmtp.Message_Version.v2) {
+      return await _v2.listMessages(conversation, start, end, limit, sort);
+    }
+    return [];
   }
 
   /// This exposes a stream of new messages in [conversations].

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -237,15 +237,6 @@ void main() {
         "I don't want to work.",
         "Bob, let's chat here about play.",
       ]);
-      expect((await bob.listBatchMessages([work, play])).length, 5);
-      await bobListening.cancel();
-      expect(transcript, [
-        "${work.topic} ${alice.address.hex}> Bob, let's chat here about work.",
-        "${work.topic} ${alice.address.hex}> Our quarterly report is due next week.",
-        "${play.topic} ${alice.address.hex}> Bob, let's chat here about play.",
-        "${play.topic} ${alice.address.hex}> I don't want to work.",
-        "${play.topic} ${alice.address.hex}> I just want to bang on my drum all day.",
-      ]);
     },
   );
 

--- a/test/conversation/conversation_v1_test.dart
+++ b/test/conversation/conversation_v1_test.dart
@@ -36,8 +36,8 @@ void main() {
       var aliceConvo = await alice.newConversation(bobAddress);
       var bobConvo = await bob.newConversation(aliceAddress);
 
-      var aliceMessages = await alice.listMessages([aliceConvo]);
-      var bobMessages = await bob.listMessages([bobConvo]);
+      var aliceMessages = await alice.listMessages(aliceConvo);
+      var bobMessages = await bob.listMessages(bobConvo);
 
       expect(aliceMessages.length, 0);
       expect(bobMessages.length, 0);
@@ -58,7 +58,7 @@ void main() {
       expect((await bob.listConversations()).length, 1);
 
       // And Bob see the message in the conversation.
-      bobMessages = await bob.listMessages([bobConvo]);
+      bobMessages = await bob.listMessages(bobConvo);
       expect(bobMessages.length, 1);
       expect(bobMessages[0].sender, aliceWallet.address);
       expect(bobMessages[0].content, "hello Bob, it's me Alice!");
@@ -66,7 +66,7 @@ void main() {
       // Bob replies
       await bob.sendMessage(bobConvo, "oh, hello Alice!");
 
-      aliceMessages = await alice.listMessages([aliceConvo]);
+      aliceMessages = await alice.listMessages(aliceConvo);
       expect(aliceMessages.length, 2);
       expect(aliceMessages[0].sender, bobWallet.address);
       expect(aliceMessages[0].content, "oh, hello Alice!");
@@ -108,7 +108,7 @@ void main() {
       var conversations = await v1.listConversations();
       for (var convo in conversations) {
         debugPrint("dm w/ ${convo.peer}");
-        var dms = await v1.listMessages([convo]);
+        var dms = await v1.listMessages(convo);
         for (var j = 0; j < dms.length; ++j) {
           var dm = dms[j];
           debugPrint("${dm.sentAt} ${dm.sender.hexEip55}> ${dm.content}");

--- a/test/conversation/conversation_v2_test.dart
+++ b/test/conversation/conversation_v2_test.dart
@@ -65,7 +65,7 @@ void main() {
       await delayToPropagate();
 
       // And Bob see the message in the conversation.
-      var bobMessages = await bob.listMessages([bobConvo]);
+      var bobMessages = await bob.listMessages(bobConvo);
       expect(bobMessages.length, 1);
       expect(bobMessages[0].sender, aliceWallet.address);
       expect(bobMessages[0].content, "hello Bob, it's me Alice!");
@@ -74,7 +74,7 @@ void main() {
       await bob.sendMessage(bobConvo, "oh, hello Alice!");
       await delayToPropagate();
 
-      var aliceMessages = await alice.listMessages([aliceConvo]);
+      var aliceMessages = await alice.listMessages(aliceConvo);
       expect(aliceMessages.length, 2);
       expect(aliceMessages[0].sender, bobWallet.address);
       expect(aliceMessages[0].content, "oh, hello Alice!");
@@ -121,7 +121,7 @@ void main() {
       var bobConvo = (await bob.listConversations())[0];
 
       // Helper to inspect transcript (from Alice's perspective).
-      getTranscript() async => (await alice.listMessages([aliceConvo]))
+      getTranscript() async => (await alice.listMessages(aliceConvo))
           .reversed
           .map((msg) => '${msg.sender.hexEip55}> ${msg.content}');
 
@@ -278,7 +278,7 @@ void main() {
       expect(bobConvo.conversationId, "example.com/valid");
 
       // Helper to inspect transcript (from Alice's perspective).
-      getTranscript() async => (await alice.listMessages([aliceConvo]))
+      getTranscript() async => (await alice.listMessages(aliceConvo))
           .reversed
           .map((msg) => '${msg.sender.hex}> ${msg.content}');
 
@@ -365,7 +365,7 @@ void main() {
       var conversations = await v2.listConversations();
       for (var convo in conversations) {
         debugPrint("dm w/ ${convo.peer}");
-        var dms = await v2.listMessages([convo]);
+        var dms = await v2.listMessages(convo);
         for (var j = 0; j < dms.length; ++j) {
           var dm = dms[j];
           debugPrint("${dm.sentAt} ${dm.sender.hexEip55}> ${dm.content}");


### PR DESCRIPTION
This PR removes `listBatchMessages` because we are moving away from being able to query multiple content topics per query to make it easier to fetch queries in a future decentralized node world. Before we merge this PR we will want to make sure our current partners aren't impacted by this change. And if they are, provide a workaround for how to move forward.

@dmccartney I'm also nervous about the performance of querying each conversations' messages on start of the background manager. LMK if you think that will slow things down significantly!

Related Android PR: https://github.com/xmtp/xmtp-android/pull/52
Related iOS PR: https://github.com/xmtp/xmtp-ios/pull/81