### PR TITLE
refactor: use BatchQuery to list messages for multiple conversations

### DIFF
--- a/lib/src/conversation/conversation.dart
+++ b/lib/src/conversation/conversation.dart
@@ -62,3 +62,8 @@ class Conversation {
     return 'Conversation{version:$version me:$me peer:$peer topic:$topic}';
   }
 }
+
+/// Sort and return the sorted list inline
+extension ListSorted<T> on List<T> {
+  List<T> sorted(int Function(T a, T b) compare) => [...this]..sort(compare);
+}

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -134,8 +134,11 @@ class ConversationManagerV1 {
     var listing = await _api.client
         .batchQuery(xmtp.BatchQueryRequest(requests: requests));
     return Future.wait(listing.responses
-        .expand((response) => response.envelopes).toList()
-        .sorted((e1, e2) => e2.timestampNs.compareTo(e1.timestampNs))
+        .expand((response) => response.envelopes)
+        .toList()
+        .sorted((e1, e2) => sort == xmtp.SortDirection.SORT_DIRECTION_ASCENDING
+            ? e1.timestampNs.compareTo(e2.timestampNs)
+            : e2.timestampNs.compareTo(e1.timestampNs))
         .map((e) => xmtp.Message.fromBuffer(e.message))
         .map((msg) => _decodedFromMessage(msg)));
   }

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -135,6 +135,7 @@ class ConversationManagerV1 {
         .batchQuery(xmtp.BatchQueryRequest(requests: requests));
     return Future.wait(listing.responses
         .expand((response) => response.envelopes).toList()
+        .sorted((e1, e2) => e2.timestampNs.compareTo(e1.timestampNs))
         .map((e) => xmtp.Message.fromBuffer(e.message))
         .map((msg) => _decodedFromMessage(msg)));
   }

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -221,6 +221,7 @@ class ConversationManagerV2 {
     var messages = await Future.wait(listing.responses
         .expand((response) => response.envelopes)
         .toList()
+        .sorted((e1, e2) => e2.timestampNs.compareTo(e1.timestampNs))
         .where((e) => convoByTopic.containsKey(e.contentTopic))
         .map((e) => _decodedFromMessage(
               convoByTopic[e.contentTopic]!,

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -221,7 +221,9 @@ class ConversationManagerV2 {
     var messages = await Future.wait(listing.responses
         .expand((response) => response.envelopes)
         .toList()
-        .sorted((e1, e2) => e2.timestampNs.compareTo(e1.timestampNs))
+        .sorted((e1, e2) => sort == xmtp.SortDirection.SORT_DIRECTION_ASCENDING
+            ? e1.timestampNs.compareTo(e2.timestampNs)
+            : e2.timestampNs.compareTo(e1.timestampNs))
         .where((e) => convoByTopic.containsKey(e.contentTopic))
         .map((e) => _decodedFromMessage(
               convoByTopic[e.contentTopic]!,

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -207,16 +207,20 @@ class ConversationManagerV2 {
       return [];
     }
     var convoByTopic = {for (var c in conversations) c.topic: c};
-    var listing = await api.client.query(xmtp.QueryRequest(
-      contentTopics: conversations.map((c) => c.topic),
-      startTimeNs: start?.toNs64(),
-      endTimeNs: end?.toNs64(),
-      pagingInfo: xmtp.PagingInfo(
-        limit: limit,
-        direction: sort,
-      ),
-    ));
-    var messages = await Future.wait(listing.envelopes
+    var requests = conversations.map((c) => xmtp.QueryRequest(
+          contentTopics: [c.topic], // Limit one topic per query
+          startTimeNs: start?.toNs64(),
+          endTimeNs: end?.toNs64(),
+          pagingInfo: xmtp.PagingInfo(
+            limit: limit,
+            direction: sort,
+          ),
+        ));
+    var listing =
+        await api.client.batchQuery(xmtp.BatchQueryRequest(requests: requests));
+    var messages = await Future.wait(listing.responses
+        .expand((response) => response.envelopes)
+        .toList()
         .where((e) => convoByTopic.containsKey(e.contentTopic))
         .map((e) => _decodedFromMessage(
               convoByTopic[e.contentTopic]!,

--- a/lib/xmtp.dart
+++ b/lib/xmtp.dart
@@ -11,4 +11,4 @@ export 'src/content/decoded.dart' show DecodedContent, DecodedMessage;
 export 'src/content/codec.dart' show Codec;
 export 'src/content/codec_registry.dart' show CodecRegistry;
 export 'src/content/text_codec.dart' show contentTypeText, TextCodec;
-export 'package:xmtp_proto/xmtp_proto.dart';
+export 'package:xmtp_proto/xmtp_proto.dart' hide DecodedMessage;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   pointycastle: ^3.6.2
   quiver: ^3.2.1
   web3dart: ^2.6.1
-  xmtp_proto: ^0.0.1-development
+  xmtp_proto: ^3.23.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR implements a single content topic per query request to make it easier to fetch queries in a future decentralized node world. It replaces the two instances of `QueryRequest` that took in multiple content topics with the new `BatchQueryRequest` which allows us to keep the current SDK structure while enforcing this new rule.

Related Android PR: https://github.com/xmtp/xmtp-android/pull/52
Related iOS PR: https://github.com/xmtp/xmtp-ios/pull/81
