### PR TITLE
feat: add release steps to README using the new Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,8 @@
-name: Release
+name: Release dry run
 on:
   push:
     branches:
-      - main
+      - ea/add-release-action
 jobs:
   dart:
     name: Release (dart)
@@ -18,5 +18,18 @@ jobs:
       - run: flutter test --dart-define=TEST_SERVER_ENABLED=true
       - run: docker-compose -p xmtp -f "tool/local-node/docker-compose.yml" down
         if: always()
+#      - name: Set release version
+#        run: |
+#          TAG=`echo ${GITHUB_REF#refs/*/}`
+#          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
+      - name: Set release version
+        run: |
+          echo "GIT_TAG=0.0.3" >> $GITHUB_ENV
+      - name: Prepublish
+        env:
+          RELEASE_VERSION: ${{ env.GIT_TAG }}
+        run: |
+          sed -i "s/version: 0.0.0/version: $RELEASE_VERSION/" ./pubspec.yaml
+      - name: Verify pubspec
+        run: cat ./pubspec.yaml
       - run: dart pub publish --dry-run
-      # TODO: drop "--dry-run" to auto-publish to pub.dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,10 @@
-name: Release dry run
+# https://dart.dev/tools/pub/automated-publishing#publishing-packages-using-github-actions
+name: Release
 on:
   push:
-    branches:
-      - ea/add-release-action
+    tags:
+    # must align with the tag-pattern configured on pub.dev
+    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
 jobs:
   dart:
     name: Release (dart)
@@ -18,18 +20,15 @@ jobs:
       - run: flutter test --dart-define=TEST_SERVER_ENABLED=true
       - run: docker-compose -p xmtp -f "tool/local-node/docker-compose.yml" down
         if: always()
-#      - name: Set release version
-#        run: |
-#          TAG=`echo ${GITHUB_REF#refs/*/}`
-#          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
       - name: Set release version
         run: |
-          echo "GIT_TAG=0.0.3" >> $GITHUB_ENV
-      - name: Prepublish
+          TAG=`echo ${GITHUB_REF#refs/*/}`
+          echo "GIT_TAG=${TAG#v}" >> $GITHUB_ENV
+      - name: Update version in pubspec
         env:
           RELEASE_VERSION: ${{ env.GIT_TAG }}
         run: |
           sed -i "s/version: 0.0.0/version: $RELEASE_VERSION/" ./pubspec.yaml
       - name: Verify pubspec
         run: cat ./pubspec.yaml
-      - run: dart pub publish --dry-run
+      - run: dart pub publish --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
+## 0.0.3
+- use batch query for listing messages
+
 ## 0.0.2-development
 - signature check fixes
 - additional performance updates
 
 ## 0.0.1-development.1
-
 - initial Developer Preview

--- a/README.md
+++ b/README.md
@@ -306,3 +306,15 @@ Here are some best practices for when to use each environment:
 The `production` network is configured to store messages indefinitely.
 XMTP may occasionally delete messages and keys from the `dev` network, and will provide
 advance notice in the [XMTP Discord community](https://discord.gg/xmtp).
+
+## Publish a new version to pub.dev
+
+1. Determine the next version number based on the [current published version](https://pub.dev/packages/xmtp) in `major.minor.patch` format.
+2. Update [CHANGELOG.md](https://github.com/xmtp/xmtp-flutter/blob/main/CHANGELOG.md) to include release notes for the new version number and merge the update into the `main` branch via a Pull Request.
+3. Once the CHANGELOG Pull Request is merged, run the following commands on the `main` branch replacing `{VERSION_NUMBER}` with the same version added to `CHANGELOG.md` in Step 2.
+```bash
+git tag -a v{VERSION_NUMBER} -m "xmtp release v{VERSION_NUMBER}"
+git push origin v{VERSION_NUMBER}
+```
+4. Watch the [GitHub Actions](https://github.com/xmtp/xmtp-flutter/actions) and ensure the `Release` Action succeeds confirming the package has been published.
+5. Ensure the new version is up to date at https://pub.dev/packages/xmtp.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,7 @@
 name: xmtp
 description: XMTP client SDK for Flutter applications.
-version: 0.0.2-development
+# Version replaced at build time in release.yml
+version: 0.0.0
 repository: https://github.com/xmtp/xmtp-flutter
 
 environment:


### PR DESCRIPTION
This PR updates `release.yml` to publish new releases on push of new release tags. I also added a blob to the README to walk thru the steps of publishing a new release. Finally, I ran a [dry run here](https://github.com/xmtp/xmtp-flutter/actions/runs/4599629975/jobs/8125233313#step:10:12) to test the version is being pulled from the GitHub Action so it will always stay in sync with the tag version. In the future, it would be cool to update the CHANGELOG.md programatically but one step at a time!

I plan to use this new Action to publish a version `v0.0.3` so I updated the CHANGELOG.md to include that update as well.