### PR TITLE
fix: use JWT token when publishing dart package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,15 +2,21 @@
 name: Release
 on:
   push:
-    tags:
-    # must align with the tag-pattern configured on pub.dev
-    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
+    branches:
+      - ea/fix-publish-auth
+#    tags:
+#    # must align with the tag-pattern configured on pub.dev
+#    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
 jobs:
   dart:
     name: Release (dart)
+    permissions:
+      id-token: write # This is required for requesting the JWT
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Setup Dart SDK with JWT token https://github.com/dart-lang/setup-dart/blob/77b84bec90e9a0d07f68a3cedd3651ba9e606a12/.github/workflows/publish.yml#L33
+      - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.7.6'
@@ -31,4 +37,4 @@ jobs:
           sed -i "s/version: 0.0.0/version: $RELEASE_VERSION/" ./pubspec.yaml
       - name: Verify pubspec
         run: cat ./pubspec.yaml
-      - run: dart pub publish --force
+      - run: dart pub publish --dry-run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,11 +2,9 @@
 name: Release
 on:
   push:
-    branches:
-      - ea/fix-publish-auth
-#    tags:
-#    # must align with the tag-pattern configured on pub.dev
-#    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
+    tags:
+    # must align with the tag-pattern configured on pub.dev
+    - 'v[0-9]+.[0-9]+.[0-9]+*' # tag-pattern on pub.dev: 'v'
 jobs:
   dart:
     name: Release (dart)
@@ -37,4 +35,4 @@ jobs:
           sed -i "s/version: 0.0.0/version: $RELEASE_VERSION/" ./pubspec.yaml
       - name: Verify pubspec
         run: cat ./pubspec.yaml
-      - run: dart pub publish --dry-run
+      - run: dart pub publish --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.4
+- publish package with GitHub Actions
+- use batch query for listing messages
+
 ## 0.0.3
 - use batch query for listing messages
 


### PR DESCRIPTION
This PR fixes a small auth issue with our publishing flow via `release.yml`. This should fix the publishing step getting stuck on auth like it did for the `v0.0.3` build: https://github.com/xmtp/xmtp-flutter/actions/runs/4608928269/jobs/8145355539#step:11:104.

I bumped the version number to `v0.0.4` in the CHANGELOG to try again.