### PR TITLE
fix: use `ecdsaCompact` signature for v1 contact bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+- General Availability release
+- Fix for publishing v1 contact bundle signatures
+
 ## 0.0.4
 - publish package with GitHub Actions
 - use batch query for listing messages

--- a/README.md
+++ b/README.md
@@ -310,8 +310,10 @@ advance notice in the [XMTP Discord community](https://discord.gg/xmtp).
 ## Publish a new version to pub.dev
 
 1. Determine the next version number based on the [current published version](https://pub.dev/packages/xmtp) in `major.minor.patch` format.
-2. Update [CHANGELOG.md](https://github.com/xmtp/xmtp-flutter/blob/main/CHANGELOG.md) to include release notes for the new version number and merge the update into the `main` branch via a Pull Request.
-3. Once the CHANGELOG Pull Request is merged, run the following commands on the `main` branch replacing `{VERSION_NUMBER}` with the same version added to `CHANGELOG.md` in Step 2.
+2. Update the `sdkVersion`  in `common/api.dart` to use the new version.
+3. Update [CHANGELOG.md](https://github.com/xmtp/xmtp-flutter/blob/main/CHANGELOG.md) to include release notes for the new version number.
+4. Merge the updates from Steps 2 & 3 into the `main` branch via a Pull Request.
+5. Checkout the `main` branch, pull the latest changes & run the following commands replacing `{VERSION_NUMBER}` with the new version.
 ```bash
 git tag -a v{VERSION_NUMBER} -m "xmtp release v{VERSION_NUMBER}"
 git push origin v{VERSION_NUMBER}

--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:grpc/grpc.dart' as grpc;
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 
-const sdkVersion = '0.0.2';
+const sdkVersion = '1.0.0';
 const clientVersion = "xmtp-flutter/$sdkVersion";
 // TODO: consider generating these ^ during build.
 

--- a/lib/src/contact.dart
+++ b/lib/src/contact.dart
@@ -232,7 +232,7 @@ xmtp.ContactBundle createContactBundleV1(xmtp.PrivateKeyBundle keys) {
             : _toPublicKey(
                 keys.v2.preKeys.first.publicKey,
                 isSignedByWallet: false,
-              )
+              ),
       ),
     ),
   );

--- a/lib/src/contact.dart
+++ b/lib/src/contact.dart
@@ -226,13 +226,13 @@ xmtp.ContactBundle createContactBundleV1(xmtp.PrivateKeyBundle keys) {
       keyBundle: xmtp.PublicKeyBundle(
         identityKey: xmtp.PublicKey()
           ..mergeFromMessage(identityKey)
-          ..signature = identityKey.signature.toWalletEcdsa(),
+          ..signature = identityKey.signature.toEcdsa(),
         preKey: isAlreadyV1
             ? keys.v1.preKeys.first.publicKey
             : _toPublicKey(
                 keys.v2.preKeys.first.publicKey,
                 isSignedByWallet: false,
-              ),
+              )
       ),
     ),
   );

--- a/test/contact_test.dart
+++ b/test/contact_test.dart
@@ -170,7 +170,7 @@ void main() {
       expect(storedV1.wallet, alice.address);
       expect(storedV1.whichVersion(), xmtp.ContactBundle_Version.v1);
       expect(storedV1.v1.keyBundle.identityKey.signature.whichUnion(),
-          xmtp.Signature_Union.walletEcdsaCompact);
+          xmtp.Signature_Union.ecdsaCompact);
       expect(storedV1.v1.keyBundle.preKey.signature.whichUnion(),
           xmtp.Signature_Union.ecdsaCompact);
       expect(storedV2.wallet, alice.address);


### PR DESCRIPTION
Relates to https://github.com/xmtp/xmtp-js/issues/371.

We were noticing some malformed v1 contact bundles causing invalid signatures on the network. It appears the root cause might be this SDK publishing a `walletEcdsaCompact` signature for v1 contact bundles instead of a `ecdsaCompact` signature.

This PR updates the v1 contact bundle to publish a `ecdsaCompact` signature. I tested creating a new identity `0xE7CAa710E60A2Ae19EdfCbF1be7aD500F4656c81` locally in the example app and confirmed I can message with xmtp.chat and the iOS app.

**Note:** This also fixes the SDK version reported to the network and adds a step to update it in the publishing docs in the README. This release will be `v1.0.0` since we are officially GA'd.