### PR TITLE
feat: use deterministic topic/keyMaterial invite generation

### DIFF
--- a/lib/src/common/crypto.dart
+++ b/lib/src/common/crypto.dart
@@ -19,6 +19,36 @@ List<int> sha256(List<int> input) => (const DartSha256().newHashSink()
     .hashSync()
     .bytes;
 
+/// This returns the calculated MAC for `message` using `secret`.
+Future<List<int>> calculateMac(
+  List<int> message,
+  List<int> secret,
+) async {
+  var mac = await Hmac(Sha256()).calculateMac(
+    message,
+    secretKey: SecretKey(secret),
+  );
+  return mac.bytes;
+}
+
+/// This consistently derives a key from the `secret` using `nonce` and `info`.
+Future<List<int>> deriveKey(
+  List<int> secret, {
+  List<int> nonce = const <int>[],
+  List<int> info = const <int>[],
+}) async {
+  final hkdf = Hkdf(
+    hmac: Hmac(Sha256()),
+    outputLength: 32,
+  );
+  final key = await hkdf.deriveKey(
+    secretKey: SecretKey(secret),
+    nonce: nonce,
+    info: info,
+  );
+  return key.bytes;
+}
+
 /// This uses the `secret` to encrypt the `message`.
 Future<xmtp.Ciphertext> encrypt(
   List<int> secret,

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -49,12 +49,13 @@ class ConversationManagerV2 {
     xmtp.InvitationV1_Context context,
   ) async {
     var peer = EthereumAddress.fromHex(address);
-    var invite = createInviteV1(context);
     var peerContact = await contacts.getUserContactV2(peer.hex);
+    var peerKeys = peerContact.v2.keyBundle;
+    var invite = await createInviteV1(auth.keys, peerKeys, context);
     var now = nowNs();
     var sealed = await encryptInviteV1(
       auth.keys,
-      peerContact.v2.keyBundle,
+      peerKeys,
       invite,
       now,
     );
@@ -334,19 +335,35 @@ class ConversationManagerV2 {
 }
 
 /// This uses the provided `context` to create a new conversation invitation.
-/// It randomly generates the topic identifier and encryption key material.
+/// To avoid duplicates, it uses the `authKeys`, `peerKeys`, and `context`
+/// to consistently generate the topic identifier and encryption key material.
 @visibleForTesting
-xmtp.InvitationV1 createInviteV1(xmtp.InvitationV1_Context context) {
-  // The topic is a random string of alphanumerics.
-  // This base64 encodes some random bytes and strips non-alphanumerics.
-  // Note: we don't rely on this being valid base64 anywhere.
-  var randomId = base64.encode(generateRandomBytes(32));
-  randomId = randomId.replaceAll(RegExp(r'[^A-Za-z0-9]'), '');
-  var topic = Topic.messageV2(randomId);
-
-  var keyMaterial = generateRandomBytes(32);
+Future<xmtp.InvitationV1> createInviteV1(
+  xmtp.PrivateKeyBundle authKeys,
+  xmtp.SignedPublicKeyBundle peerKeys,
+  xmtp.InvitationV1_Context context,
+) async {
+  // This mirrors xmtp-js -- see InMemoryKeystore.createInvite()
+  var secret = compute3DHSecret(
+    createECPrivateKey(authKeys.identity.privateKey),
+    createECPrivateKey(authKeys.preKeys.first.privateKey),
+    createECPublicKey(peerKeys.identityKey.publicKeyBytes),
+    createECPublicKey(peerKeys.preKey.publicKeyBytes),
+    false,
+  );
+  var addresses = [
+    authKeys.wallet.hexEip55,
+    peerKeys.wallet.hexEip55,
+  ]..sort();
+  var msg = (context.conversationId ?? "") + addresses.join("");
+  var topicId = bytesToHex(await calculateMac(utf8.encode(msg), secret));
+  var keyMaterial = await deriveKey(
+    secret,
+    nonce: utf8.encode('__XMTP__INVITATION__SALT__XMTP__'),
+    info: utf8.encode(['0', ...addresses].join('|')),
+  );
   return xmtp.InvitationV1(
-    topic: topic,
+    topic: Topic.messageV2(topicId),
     aes256GcmHkdfSha256: xmtp.InvitationV1_Aes256gcmHkdfsha256(
       keyMaterial: keyMaterial,
     ),


### PR DESCRIPTION
This produces consistent `topic` and `keyMaterial` for invites created to the same `peer` and `conversationId`.

This implements #62 