### PR TITLE
fix: list all conversations across multiple query pages

### DIFF
--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -83,6 +83,22 @@ class Api {
   }
 }
 
+extension QueryPaginator on xmtp.MessageApiClient {
+  /// This is a helper for paginating through a full query.
+  /// It yields all the envelopes in the query using the paging info
+  /// from the prior response to fetch the next page.
+  Stream<xmtp.Envelope> envelopes(xmtp.QueryRequest req) async* {
+    xmtp.QueryResponse res;
+    do {
+      res = await query(req);
+      for (var envelope in res.envelopes) {
+        yield envelope;
+      }
+      req.pagingInfo.cursor = res.pagingInfo.cursor;
+    } while (res.envelopes.isNotEmpty && res.pagingInfo.hasCursor());
+  }
+}
+
 /// Creates a [Comparator] that implements the [sort] over [xmtp.Envelope].
 Comparator<xmtp.Envelope> envelopeComparator(xmtp.SortDirection? sort) =>
     (e1, e2) => sort == xmtp.SortDirection.SORT_DIRECTION_ASCENDING

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -69,7 +69,7 @@ class ConversationManagerV1 {
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
-    var listing = await _api.client.query(xmtp.QueryRequest(
+    var listing = _api.client.envelopes(xmtp.QueryRequest(
       contentTopics: [Topic.userIntro(_me.hex)],
       startTimeNs: start?.toNs64(),
       endTimeNs: end?.toNs64(),
@@ -78,9 +78,9 @@ class ConversationManagerV1 {
         direction: sort,
       ),
     ));
-    var conversations = await Future.wait(listing.envelopes
-        .map((e) => xmtp.Message.fromBuffer(e.message))
-        .map((msg) => _conversationFromIntro(msg)));
+    var conversations = listing
+        .asyncMap((e) => xmtp.Message.fromBuffer(e.message))
+        .asyncMap((msg) => _conversationFromIntro(msg));
     // Remove duplicates by topic identifier.
     var unique = <String>{};
     return conversations.where((c) => unique.add(c.topic)).toList();

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -90,7 +90,7 @@ class ConversationManagerV2 {
     int? limit,
     xmtp.SortDirection? sort,
   ]) async {
-    var listing = await api.client.query(xmtp.QueryRequest(
+    var listing = api.client.envelopes(xmtp.QueryRequest(
       contentTopics: [Topic.userInvite(_me.hex)],
       startTimeNs: start?.toNs64(),
       endTimeNs: end?.toNs64(),
@@ -99,8 +99,8 @@ class ConversationManagerV2 {
         direction: sort,
       ),
     ));
-    var conversations = await Future.wait(
-        listing.envelopes.map((e) => _conversationFromEnvelope(e)));
+    var conversations = listing
+        .asyncMap((e) => _conversationFromEnvelope(e));
     var unique = <String>{};
     return conversations
         // Remove nulls (which are discarded bad envelopes).

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -448,34 +448,62 @@ void main() {
     },
   );
 
+  test(
+    skip: "manual testing",
+    "conversations: listing conversations with pagination",
+      () async {
+        var aliceWallet = EthPrivateKey.createRandom(Random.secure()).asSigner();
+        var aliceApi = createTestServerApi();
+        var alice = await Client.createFromWallet(aliceApi, aliceWallet);
+        await _startRandomConversationsWith(
+          alice.address.hex,
+          // > 100 (the server page size)
+          conversationCount: 105,
+          messagesPerConvo: 1,
+        );
+        var conversations = await alice.listConversations();
+        expect(conversations.length, 105);
+      }
+  );
+
   // This creates a user and sends them lots of messages from other users.
   // This aims to be useful for prepping an account to test performance.
   test(
     skip: "manual testing",
     "messaging: send lots of messages to me",
     () async {
-      // Starts this many conversations:
-      const conversationCount = 30;
-      // ... with this many messages in each:
-      const messagesPerCount = 5;
-
       var recipientKey = EthPrivateKey.createRandom(Random.secure());
       var recipientClient = await Client.createFromWallet(
           createTestServerApi(), recipientKey.asSigner());
       var recipient = recipientClient.address.hex;
       debugPrint('sending messages to $recipient');
       debugPrint(' private key: ${bytesToHex(recipientKey.privateKey)}');
-      for (var i = 0; i < conversationCount; ++i) {
-        var senderKey = EthPrivateKey.createRandom(Random.secure());
-        var senderWallet = senderKey.asSigner();
-        var senderApi = createTestServerApi(debugLogRequests: false);
-        var sender = await Client.createFromWallet(senderApi, senderWallet);
-        debugPrint('${i + 1}/$conversationCount: '
-            'sending $messagesPerCount from ${sender.address.hex}');
-        var convo = await sender.newConversation(recipient);
-        await Future.wait(Iterable.generate(
-          messagesPerCount,
-          (_) => sender.sendMessage(convo, """
+      await _startRandomConversationsWith(
+        recipient,
+        conversationCount: 200,
+        messagesPerConvo: 5,
+      );
+    },
+  );
+}
+
+/// Helper to seed random conversations in a test account.
+Future _startRandomConversationsWith(
+  String recipientAddress, {
+  conversationCount = 5,
+  messagesPerConvo = 1,
+}) async {
+  for (var i = 0; i < conversationCount; ++i) {
+    var senderKey = EthPrivateKey.createRandom(Random.secure());
+    var senderWallet = senderKey.asSigner();
+    var senderApi = createTestServerApi(debugLogRequests: false);
+    var sender = await Client.createFromWallet(senderApi, senderWallet);
+    debugPrint('${i + 1}/$conversationCount: '
+        'sending $messagesPerConvo from ${sender.address.hex}');
+    var convo = await sender.newConversation(recipientAddress);
+    await Future.wait(Iterable.generate(
+      messagesPerConvo,
+      (_) => sender.sendMessage(convo, """
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, 
 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. 
 Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris 
@@ -484,10 +512,8 @@ reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
 pariatur. Excepteur sint occaecat cupidatat non proident, sunt in 
 culpa qui officia deserunt mollit anim id est laborum.
 """),
-        ));
-      }
-    },
-  );
+    ));
+  }
 }
 
 /// Simple [Codec] for sending [int] values around.


### PR DESCRIPTION
This modifies the `listConversations` call to properly gather all conversations across the paginated results.

Fixes https://github.com/xmtp/xmtp-flutter/issues/70