### PR TITLE
fix: batch paginate across multiple queries

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -148,7 +148,7 @@ class Client implements Codec<DecodedContent> {
   /// If [start] or [end] are specified then this will only list conversations
   /// created at or after [start] and at or before [end].
   ///
-  /// If [limit] is specified then this returns no more than [limit] conversations.
+  /// If [limit] is specified then results are pulled in pages of that size.
   ///
   /// If [sort] is specified then that will control the sort order.
   Future<List<Conversation>> listConversations({
@@ -203,7 +203,7 @@ class Client implements Codec<DecodedContent> {
   /// If [start] or [end] are specified then this will only list messages
   /// sent at or after [start] and at or before [end].
   ///
-  /// If [limit] is specified then this returns no more than [limit] messages.
+  /// If [limit] is specified then results are pulled in pages of that size.
   ///
   /// If [sort] is specified then that will control the sort order.
   Future<List<DecodedMessage>> listMessages(
@@ -213,19 +213,33 @@ class Client implements Codec<DecodedContent> {
     int? limit,
     xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
   }) =>
-      _conversations.listMessages([conversation], start, end, limit, sort);
+      _conversations.listMessages(
+        [conversation],
+        start: start,
+        end: end,
+        limit: limit,
+        sort: sort,
+      );
 
   /// This lists messages sent to the [conversations].
   /// This is identical to [listMessages] except it pulls messages from
   /// multiple conversations in a single call.
   Future<List<DecodedMessage>> listBatchMessages(
     Iterable<Conversation> conversations, {
+    Iterable<Pagination>? paginations,
     DateTime? start,
     DateTime? end,
     int? limit,
     xmtp.SortDirection sort = xmtp.SortDirection.SORT_DIRECTION_DESCENDING,
   }) =>
-      _conversations.listMessages(conversations, start, end, limit, sort);
+      _conversations.listMessages(
+        conversations,
+        paginations: paginations,
+        start: start,
+        end: end,
+        limit: limit,
+        sort: sort,
+      );
 
   /// This exposes a stream of new messages sent to the [conversation].
   /// For streaming multiple conversations, see [streamBatchMessages].

--- a/lib/src/conversation/conversation_v1.dart
+++ b/lib/src/conversation/conversation_v1.dart
@@ -121,32 +121,30 @@ class ConversationManagerV1 {
   }
 
   Future<List<DecodedMessage>> listMessages(
-    Iterable<Conversation> conversations, [
-    DateTime? start,
-    DateTime? end,
-    int? limit,
+    Iterable<Conversation> conversations, {
+    Iterable<Pagination>? paginations,
     xmtp.SortDirection? sort,
-  ]) async {
+  }) async {
     if (conversations.isEmpty) {
       return [];
     }
-    var requests = conversations.map((c) => xmtp.QueryRequest(
-          contentTopics: [c.topic], // Limit one topic per query
-          startTimeNs: start?.toNs64(),
-          endTimeNs: end?.toNs64(),
+    var ps = paginations?.toList();
+    var requests = enumerate(conversations).map((c) => xmtp.QueryRequest(
+          contentTopics: [c.value.topic], // Limit one topic per query
+          startTimeNs: ps?[c.index].start?.toNs64(),
+          endTimeNs: ps?[c.index].end?.toNs64(),
           pagingInfo: xmtp.PagingInfo(
-            limit: limit,
-            direction: sort,
+            limit: ps?[c.index].limit,
+            direction: ps?[c.index].sort,
           ),
         ));
     // Batch up the requests to avoid requesting too many in one shot.
     var batches = partition(requests, maxQueryRequestsPerBatch);
     var compare = envelopeComparator(sort);
     var results = await Future.wait(batches.map((batch) => _api.client
-        .batchQuery(xmtp.BatchQueryRequest(requests: batch))
-        .then((res) => res.responses.expand((r) => r.envelopes))
-        .then((envs) => envs.toList().sorted(compare))));
-    var listing = merge(results, compare);
+        .batchEnvelopes(xmtp.BatchQueryRequest(requests: batch))
+        .toList()));
+    var listing = results.reduce((l, r) => l..addAll(r)).sorted(compare);
     var messages = await Future.wait(listing
         .map((e) => xmtp.Message.fromBuffer(e.message))
         .map((msg) => _decodedFromMessage(msg)));

--- a/test/conversation/conversation_v2_test.dart
+++ b/test/conversation/conversation_v2_test.dart
@@ -281,7 +281,6 @@ void main() {
     },
   );
 
-
   test(
     "v2 messaging: low-level deterministic invite creation",
     () async {
@@ -290,10 +289,10 @@ void main() {
       var aliceKeys = await aliceWallet.createIdentity(generateKeyPair());
       var bobKeys = await bobWallet.createIdentity(generateKeyPair());
       makeInvite(String conversationId) => createInviteV1(
-        aliceKeys,
-        createContactBundleV2(bobKeys).v2.keyBundle,
-        xmtp.InvitationV1_Context(conversationId: conversationId),
-      );
+            aliceKeys,
+            createContactBundleV2(bobKeys).v2.keyBundle,
+            xmtp.InvitationV1_Context(conversationId: conversationId),
+          );
 
       // Repeatedly making the same invite should use the same topic/keys
       var original = await makeInvite("example.com/conversation-foo");


### PR DESCRIPTION
This modifies the `listMessages` / `listBatchMessages` calls to properly gather all results across multiple pages. This uses batch queries to get the initial page and any subsequent pages.

Fixes #71 