### PR TITLE
fix: update the invitation to create topics without direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.2.1
+- fix: make topics actually deterministic in all directions
+
 ## 1.2.0
 - feat: implement codecs for attachment, reaction, and reply
 - fix: batch paginate across multiple queries 

--- a/lib/src/common/api.dart
+++ b/lib/src/common/api.dart
@@ -4,7 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:grpc/grpc.dart' as grpc;
 import 'package:xmtp_proto/xmtp_proto.dart' as xmtp;
 
-const sdkVersion = '1.2.0';
+const sdkVersion = '1.2.1';
 const clientVersion = "xmtp-flutter/$sdkVersion";
 // TODO: consider generating these ^ during build.
 

--- a/lib/src/conversation/conversation_v2.dart
+++ b/lib/src/conversation/conversation_v2.dart
@@ -356,16 +356,19 @@ Future<xmtp.InvitationV1> createInviteV1(
   xmtp.InvitationV1_Context context,
 ) async {
   // This mirrors xmtp-js -- see InMemoryKeystore.createInvite()
+  var myAddress = authKeys.wallet.hexEip55;
+  var theirAddress = peerKeys.wallet.hexEip55;
+
   var secret = compute3DHSecret(
     createECPrivateKey(authKeys.identity.privateKey),
     createECPrivateKey(authKeys.preKeys.first.privateKey),
     createECPublicKey(peerKeys.identityKey.publicKeyBytes),
     createECPublicKey(peerKeys.preKey.publicKeyBytes),
-    false,
+    myAddress.compareTo(theirAddress) < 0,
   );
   var addresses = [
-    authKeys.wallet.hexEip55,
-    peerKeys.wallet.hexEip55,
+    myAddress,
+    theirAddress,
   ]..sort();
   var msg = (context.conversationId ?? "") + addresses.join(",");
   var topicId = bytesToHex(await calculateMac(utf8.encode(msg), secret));


### PR DESCRIPTION
Part of https://github.com/xmtp/xmtp-js/pull/449

Lets make topics deterministic in either invite direction