### PR TITLE
Removing unnecessary platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,3 @@ doc/api/
 *.js_
 *.js.deps
 *.js.map
-
-# example
-example/linux
-example/macos
-example/windows
-example/web

--- a/example/.metadata
+++ b/example/.metadata
@@ -21,18 +21,6 @@ migration:
     - platform: ios
       create_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
       base_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-    - platform: linux
-      create_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-      base_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-    - platform: macos
-      create_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-      base_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-    - platform: web
-      create_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-      base_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-    - platform: windows
-      create_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
-      base_revision: 7f20e5d18ce4cb80c621533090a7c5113f5bdc52
 
   # User provided section
 


### PR DESCRIPTION
### Expectations
- Removing the references to the platforms that are not supported in this SDK according to the comments made by @dmccartney in PR -> https://github.com/xmtp/xmtp-flutter/pull/101/files 